### PR TITLE
fix: remove broken deep-tree-echo LFS source asset

### DIFF
--- a/consciousness/Content/Live2DModels/deep-tree-echo/ReadMe.txt
+++ b/consciousness/Content/Live2DModels/deep-tree-echo/ReadMe.txt
@@ -60,6 +60,7 @@ Model Data Composition
 ------------------------------
 
   Model Data (cmo3) - Main editable model file
+  Note: the editable source file may be omitted from some clones; runtime assets in /runtime are sufficient for execution.
   Motion (can3) - Animation data
   Runtime folder - Built-in files for execution:
   ・Model data (moc3)

--- a/consciousness/Content/Live2DModels/deep-tree-echo/deep_tree_echo.cmo3
+++ b/consciousness/Content/Live2DModels/deep-tree-echo/deep_tree_echo.cmo3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3649c222bb0b7555f0fa6e49a762f26446af0f2744beef138f803ccb0b2b4a42
-size 26830998


### PR DESCRIPTION
## Summary\nThis fixes the repository clone failure caused by a missing Git LFS object for .\n\n## Changes\n- remove the broken  LFS pointer file that cannot be downloaded because the object returns 404\n- document that the editable  source file is optional for runtime execution because the  assets are sufficient\n\n## Why this fixes the error\nThe failing automation aborts during checkout when Git LFS attempts to smudge the missing object. Removing the stale LFS-tracked source asset prevents clone checkout from requesting the nonexistent object while preserving the runtime model files used by the app.\n