### PR TITLE
Add Copilot setup workflow to avoid LFS bootstrap failures

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,45 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 59
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository without automatic Git LFS downloads
+        uses: actions/checkout@v5
+        with:
+          lfs: false
+          submodules: false
+
+      - name: Configure Git LFS for on-demand pulls
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if git lfs version >/dev/null 2>&1; then
+            git lfs install --local --skip-smudge
+            git config --local lfs.fetchexclude "consciousness/Content/Live2DModels/deep-tree-echo/runtime/deep_tree_echo.4096/texture_00.png"
+            echo "Configured Git LFS for manual, path-scoped pulls."
+          else
+            echo "git-lfs is not available on this runner; continuing without LFS preconfiguration."
+          fi
+
+      - name: Verify repository checkout state
+        shell: bash
+        run: |
+          set -euo pipefail
+          git status --short
+          test -f README.md


### PR DESCRIPTION
## Summary

Adds a copilot-setup-steps workflow so Copilot cloud agent checks out the repository without automatic Git LFS smudge downloads during bootstrap.

## Why

Agent sessions were failing during initial clone or checkout because the repository contains Git LFS pointers whose backing objects currently return 404 from the LFS remote, including consciousness/Content/Live2DModels/deep-tree-echo/runtime/deep_tree_echo.4096/texture_00.png.

## What this changes

- Adds .github/workflows/copilot-setup-steps.yml
- Uses actions/checkout@v5 with lfs: false
- Configures Git LFS locally for on-demand pulls rather than clone-time smudging
- Verifies that the working tree is usable after checkout

## Notes

This unblocks Copilot cloud agent bootstrap, but it does not restore the missing LFS objects themselves. Those assets still need to be re-uploaded or otherwise recovered separately.